### PR TITLE
SCRUM-81

### DIFF
--- a/UI/Renderers/DefaultImplementations/DefaultGameFrameRenderer.cs
+++ b/UI/Renderers/DefaultImplementations/DefaultGameFrameRenderer.cs
@@ -54,7 +54,7 @@ namespace SnakeGame.UI.Renderers.DefaultImplementations
 
                     Console.ForegroundColor = curr switch
                     {
-                        "*" => ConsoleColor.DarkGreen,
+                        "*" => ConsoleColor.Green,
                         "@" => ConsoleColor.Green,
                         "●" => ConsoleColor.Red,
                         _ => ConsoleColor.White


### PR DESCRIPTION
Implementation of SCRUM-81

Change Snake Color to lightgreen

--- Implementation Plan ---

# Implementation Plan

## Conceptual Checklist

- Locate the snake color implementation in the rendering system
- Identify available ConsoleColor options for green shades
- Determine the best interpretation of 'lightgreen' given .NET constraints
- Modify the color switch statement in the game renderer
- Test the visual appearance in the console

## Overview

Change the snake's display color to light green by modifying the color assignments in DefaultGameFrameRenderer.cs. Since ConsoleColor.Green is the brightest green available in the .NET console color palette, both snake head and body will be changed to this color for a uniform light green appearance.

## Assumptions and Rules from CLAUDE.md

- **Assumption**: 'lightgreen' means using ConsoleColor.Green (the brightest available green)
- **Rule (Project CLAUDE.md)**: "Console-based rendering with color support and UTF-8 encoding" - confirms color changes are supported
- **Rule (Project CLAUDE.md)**: Snake rendering uses special characters: '@' for head, '*' for body
- **Rule (Global)**: "Avoid backwards-compatibility hacks" - make clean color changes without preserving old colors

## Step-by-Step Implementation

1. Open DefaultGameFrameRenderer.cs
   - Dependencies: None
   - Tools/Files: Read UI/Renderers/DefaultImplementations/DefaultGameFrameRenderer.cs

2. Locate the DrawMap method with color switch statement (around line 55)
   - Dependencies: Step 1 completion
   - Tools/Files: Edit tool on identified lines

3. Change snake colors in switch expression
   - Change `"*" => ConsoleColor.DarkGreen` to `"*" => ConsoleColor.Green`
   - Keep `"@" => ConsoleColor.Green` (already light green)
   - Dependencies: Step 2 completion
   - Tools/Files: Edit DefaultGameFrameRenderer.cs

4. Build and test the game
   - Dependencies: Step 3 completion  
   - Tools/Files: Bash (dotnet build, dotnet run)

## Error Handling and Uncertainties

- **ConsoleColor limitation**: If uniform Green appears too bright, could consider keeping head/body distinction with Green/DarkGreen
- **Platform differences**: Console colors may render slightly differently on Windows/Linux/Mac terminals