### PR TITLE
SCRUM-97

### DIFF
--- a/UI/Renderers/DefaultImplementations/DefaultGameFrameRenderer.cs
+++ b/UI/Renderers/DefaultImplementations/DefaultGameFrameRenderer.cs
@@ -54,8 +54,8 @@ namespace SnakeGame.UI.Renderers.DefaultImplementations
 
                     Console.ForegroundColor = curr switch
                     {
-                        "*" => ConsoleColor.DarkGreen,
-                        "@" => ConsoleColor.Green,
+                        "*" => ConsoleColor.DarkYellow,
+                        "@" => ConsoleColor.Yellow,
                         "●" => ConsoleColor.Red,
                         _ => ConsoleColor.White
                     };


### PR DESCRIPTION
Implementation of SCRUM-97

Change Snake Color To Yellow

--- Implementation Plan ---

# Implementation Plan

## Conceptual Checklist

- Locate the snake color rendering logic in the codebase
- Identify all places where snake colors are defined
- Understand the current color scheme (head vs body distinction)
- Apply the color change consistently
- Test the visual output to ensure readability

## Overview

Change the snake's visual appearance from green (DarkGreen body, Green head) to yellow colors in the console-based Snake game.

## Assumptions and Rules from CLAUDE.md

- **Assumption**: The snake should maintain visual distinction between head and body using different shades of yellow
- **Rule from project CLAUDE.md**: Follow SOLID principles and maintain the existing architecture patterns
- **Rule from project CLAUDE.md**: Use the existing Facade pattern in the UI system
- **Build command**: Use `dotnet build` and `dotnet run` for testing (from CLAUDE.md)

## Step-by-Step Implementation

1. Modify snake color in DefaultGameFrameRenderer.cs
   - Dependencies: None
   - Tools/Files: Edit tool for `/UI/Renderers/DefaultImplementations/DefaultGameFrameRenderer.cs`
   - Change line 57: `"*" => ConsoleColor.DarkGreen` to `"*" => ConsoleColor.DarkYellow`
   - Change line 58: `"@" => ConsoleColor.Green` to `"@" => ConsoleColor.Yellow`

2. Build and test the changes
   - Dependencies: Step 1 completion
   - Tools: Bash for `dotnet build`
   - Verify compilation success

3. Run the game to visually verify
   - Dependencies: Step 2 completion  
   - Tools: Bash for `dotnet run`
   - Confirm snake appears in yellow with proper head/body distinction

## Error Handling and Uncertainties

- **Color availability**: ConsoleColor.DarkYellow might not provide sufficient contrast. If visibility is poor, consider using ConsoleColor.Yellow for both or ConsoleColor.Yellow for body and ConsoleColor.White for head.
- **Terminal compatibility**: Some terminals may render colors differently. Test on target environment if specified.