### PR TITLE
SCRUM-169

### DIFF
--- a/UI/Renderers/DefaultImplementations/DefaultGameFrameRenderer.cs
+++ b/UI/Renderers/DefaultImplementations/DefaultGameFrameRenderer.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using SnakeGame.Controllers;
 using SnakeGame.Structs;
 using SnakeGame.UI.Renderers.Interfaces;
@@ -54,8 +54,8 @@ namespace SnakeGame.UI.Renderers.DefaultImplementations
 
                     Console.ForegroundColor = curr switch
                     {
-                        "*" => ConsoleColor.DarkGreen,
-                        "@" => ConsoleColor.Green,
+                        "*" => ConsoleColor.DarkYellow,
+                        "@" => ConsoleColor.Yellow,
                         "●" => ConsoleColor.Red,
                         _ => ConsoleColor.White
                     };


### PR DESCRIPTION
Implementation of SCRUM-169

Change Snake Color To Yellow

--- Implementation Plan ---

# Execution Plan - Change Snake Color to Yellow

## 1. Conceptual Checklist
- [x] Confirm `ConsoleColor` enumeration contains `Yellow` and `DarkYellow`.
- [x] Locate the rendering logic for the Snake entity in `DefaultGameFrameRenderer.cs`.
- [x] Determine the mapping strategy to preserve the visual distinction between the Snake's head and body.

## 2. Overview
Modify the `DefaultGameFrameRenderer` to render the Snake entity using `ConsoleColor.Yellow` and `ConsoleColor.DarkYellow` instead of the current Green variants. This ensures the snake appears yellow while maintaining the visual contrast between the head (`@`) and the body (`*`).

## 3. Assumptions & Rules
- **Assumption**: The user desires the visual change in the main gameplay view.
- **Assumption**: Preserving the existing pattern of a brighter color for the head and a darker color for the body is preferred for visual clarity.
- **Rule**: Only modify the rendering logic; do not alter game state or entity logic.

## 4. Step-by-Step Implementation Plan

1.  **Open File**: `UI/Renderers/DefaultImplementations/DefaultGameFrameRenderer.cs`.
2.  **Locate Method**: Find the `private static void DrawMap(string[,] map, int levelNumber)` method.
3.  **Update Color Logic**: Inside the `DrawMap` method, locate the switch expression assigning `Console.ForegroundColor` based on the `curr` string variable.
4.  **Modify Body Color**: Change the case for `"*"` (Snake Body) from `ConsoleColor.DarkGreen` to `ConsoleColor.DarkYellow`.
5.  **Modify Head Color**: Change the case for `"@"` (Snake Head) from `ConsoleColor.Green` to `ConsoleColor.Yellow`.
6.  **Verify**: Ensure no other colors (like the Apple `"●"` or walls) are accidentally modified.

## 5. Error Handling
- **Visual Clarity**: If `DarkYellow` appears too brown on specific terminal emulators, consider using `Yellow` for the body and `White` for the head in a future iteration, but strictly follow the `Yellow` request for now.