### PR TITLE
SCRUM-249 Change Snake Color To Red

### DIFF
--- a/UI/Renderers/DefaultImplementations/DefaultGameFrameRenderer.cs
+++ b/UI/Renderers/DefaultImplementations/DefaultGameFrameRenderer.cs
@@ -54,8 +54,8 @@ namespace SnakeGame.UI.Renderers.DefaultImplementations
 
                     Console.ForegroundColor = curr switch
                     {
-                        "*" => ConsoleColor.DarkGreen,
-                        "@" => ConsoleColor.Green,
+                        "*" => ConsoleColor.DarkRed,
+                        "@" => ConsoleColor.Red,
                         "●" => ConsoleColor.Red,
                         _ => ConsoleColor.White
                     };


### PR DESCRIPTION
Implementation of SCRUM-249

Change Snake Color To Red

## Conceptual Checklist

- Identify the exact location where snake colors are defined
- Understand the current color pattern (head vs body distinction)
- Plan the minimal change required
- Verify no other files reference snake colors
- Apply the change following existing code conventions

## Overview

Change the snake color from green to red in the console-based Snake game. Currently, the snake head is `Green` and body is `DarkGreen`. The change will modify these to red colors.

## Assumptions and Rules from CLAUDE.md

**Assumptions:**
- Maintain head/body visual distinction using Red (head) and DarkRed (body)
- No other rendering logic references snake colors

**Rules from project CLAUDE.md:**
- Build command: `dotnet build`
- Run command: `dotnet run`

## Step-by-Step Implementation

1. **Modify snake color in DefaultGameFrameRenderer.cs**
- File: `/tmp/claude-workspace/SnakeGame/89f2358b-627b-4796-a317-00a50bdd307a/UI/Renderers/DefaultImplementations/DefaultGameFrameRenderer.cs`
- Lines 55-61: Change the switch expression:
- `"*" => ConsoleColor.DarkGreen` → `"*" => ConsoleColor.DarkRed`
- `"@" => ConsoleColor.Green` → `"@" => ConsoleColor.Red`
- Dependencies: None

2. **Build and verify**
- Run `dotnet build` to ensure no compilation errors

## Error Handling and Uncertainties

- **Low risk:** The change is isolated to a single switch expression with no dependencies
- **Color conflict:** Apple is already Red - if same-shade red is chosen for snake, visual distinction may be reduced. Using DarkRed for body mitigates this.