### PR TITLE
SCRUM-256

### DIFF
--- a/UI/Renderers/DefaultImplementations/DefaultGameFrameRenderer.cs
+++ b/UI/Renderers/DefaultImplementations/DefaultGameFrameRenderer.cs
@@ -54,8 +54,8 @@ namespace SnakeGame.UI.Renderers.DefaultImplementations
 
                     Console.ForegroundColor = curr switch
                     {
-                        "*" => ConsoleColor.DarkGreen,
-                        "@" => ConsoleColor.Green,
+                        "*" => ConsoleColor.Red,
+                        "@" => ConsoleColor.Red,
                         "●" => ConsoleColor.Red,
                         _ => ConsoleColor.White
                     };


### PR DESCRIPTION
Implementation of SCRUM-256

Change Snake Color To Red

## Conceptual Checklist
- Identify where snake colors are assigned during rendering.
- Verify which symbols represent the snake head ('@') and body ('*').
- Confirm renderer registration in GameDependencyConfig to ensure the targeted class is in use.
- Update color mapping to make the snake red.
- Consider (optional) apple color adjustment if contrast is required.
- Add a small rendering-color mapping test (by extracting a mapping function) to prevent regressions.

## Overview
Change the snake’s on-screen color to red in the console-based renderer. The snake head ('@') and body ('*') are colored in UI/Renderers/DefaultImplementations/DefaultGameFrameRenderer.DrawMap via Console.ForegroundColor mapping.

## Assumptions & Rules
- "Snake color" refers to both head ('@') and body ('*').
- Apple color ('●') remains red unless otherwise specified.
- DefaultGameFrameRenderer is the active IGameFrameRenderer.
- No changes to snake glyphs ('@', '*') or apple glyph ('●').

## Step-by-Step Implementation Plan
1. Open UI/Renderers/DefaultImplementations/DefaultGameFrameRenderer.cs and locate DrawMap(string[,] map, int levelNumber).
2. In the color selection switch on variable `curr`, update mappings:
   - Map "*" to ConsoleColor.Red (currently ConsoleColor.DarkGreen).
   - Map "@" to ConsoleColor.Red (currently ConsoleColor.Green).
   - Leave "●" as ConsoleColor.Red unless contrast changes are requested.
3. (Optional, contrast tweak) If requested, change the apple mapping from "●" to a different color (e.g., ConsoleColor.Yellow) within the same switch block.
4. Verify that IGameFrameRenderer is resolved to DefaultGameFrameRenderer:
   - Open GameDependencyConfig.cs and ensure services.AddSingleton<IGameFrameRenderer, DefaultGameFrameRenderer>(); (or equivalent) is present. If not, update the binding accordingly.
5. Rebuild the project (SnakeGame.csproj) to ensure no compile issues.
6. Manual validation:
   - Launch the game via Program.cs -> Main() and confirm the snake (both head and body) render as red while apple remains visible.

## Error Handling
- Ensure Console.ForegroundColor is set per cell as already implemented; no additional reset required because the renderer sets color for each printed symbol.
- If console themes reduce red visibility, consider DarkRed as a fallback; document the alternative mapping in a code comment near the switch block.
- If a different renderer is registered, update the DI binding in GameDependencyConfig to use DefaultGameFrameRenderer or replicate the same color mapping changes in the bound renderer.