### PR TITLE
SCRUM-261

### DIFF
--- a/UI/Renderers/DefaultImplementations/DefaultGameFrameRenderer.cs
+++ b/UI/Renderers/DefaultImplementations/DefaultGameFrameRenderer.cs
@@ -54,8 +54,8 @@ namespace SnakeGame.UI.Renderers.DefaultImplementations
 
                     Console.ForegroundColor = curr switch
                     {
-                        "*" => ConsoleColor.DarkGreen,
-                        "@" => ConsoleColor.Green,
+                        "*" => ConsoleColor.Yellow,
+                        "@" => ConsoleColor.Yellow,
                         "●" => ConsoleColor.Red,
                         _ => ConsoleColor.White
                     };


### PR DESCRIPTION
Implementation of SCRUM-261

Сhange Snake Color To Yellow

## Conceptual Checklist
- Identify where snake color is set during frame rendering.
- Ensure both head ("@") and body ("*") symbols get updated to Yellow consistently.
- Keep other elements (apple "●", borders "#", text) unchanged.
- Avoid side effects by limiting changes to the renderer responsible for in-game frames.

## Overview
Change the visual color of the snake during gameplay to Yellow by updating the color mapping used when drawing the map in the console renderer.

## Assumptions & Rules
- Both snake head ("@") and body ("*") should be Yellow (pending confirmation).
- Apple ("●") remains Red; borders remain as-is; score text color (currently Yellow) remains unchanged.
- Only the in-game frame renderer needs modification: UI/Renderers/DefaultImplementations/DefaultGameFrameRenderer.cs.
- No behavioral/gameplay logic (movement, spawning) is affected.

## Step-by-Step Implementation Plan
1. Open UI/Renderers/DefaultImplementations/DefaultGameFrameRenderer.cs.
2. In DrawMap(string[,] map, int levelNumber), locate the switch expression assigning Console.ForegroundColor based on the current cell symbol (variables: "curr").
3. Update the mapping so that:
   - The case for "*" maps to ConsoleColor.Yellow (replacing ConsoleColor.DarkGreen).
   - The case for "@" maps to ConsoleColor.Yellow (replacing ConsoleColor.Green).
   - Leave the cases for "●" (Red) and default (White) unchanged.
4. Save changes; do not modify any logic in ClearSnakeFromMap, PlaceSnake, or other methods.
5. Ensure dependency injection continues to use DefaultGameFrameRenderer via DefaultGameUIFacade without additional changes (no DI config updates required).

## Error Handling
- Console color state: The renderer already sets Console.ForegroundColor per cell; no additional resets are needed beyond existing behavior. Ensure no accidental removal of Console.ResetColor or color assignments.
- Readability considerations: With both the snake and score using Yellow, ensure contrast on your terminal background is acceptable. If contrast issues arise, consider DarkYellow only if approved.