### PR TITLE
SCRUM-262

### DIFF
--- a/UI/Renderers/DefaultImplementations/DefaultGameFrameRenderer.cs
+++ b/UI/Renderers/DefaultImplementations/DefaultGameFrameRenderer.cs
@@ -54,8 +54,8 @@ namespace SnakeGame.UI.Renderers.DefaultImplementations
 
                     Console.ForegroundColor = curr switch
                     {
-                        "*" => ConsoleColor.DarkGreen,
-                        "@" => ConsoleColor.Green,
+                        "*" => ConsoleColor.Yellow,
+                        "@" => ConsoleColor.Yellow,
                         "●" => ConsoleColor.Red,
                         _ => ConsoleColor.White
                     };


### PR DESCRIPTION
Implementation of SCRUM-262

Change Snake Color To Yellow

## Conceptual Checklist
- Identify where rendering colors are assigned.
- Confirm which symbols represent the snake head and body.
- Change both head and body colors to Yellow.
- Ensure no unintended side effects on other UI elements (score, borders, apple color).
- Build and manually verify rendering in console.

## Overview
Change the on-screen snake color to Yellow in the console rendering pipeline. The snake head is represented by '@' and the body by '*', both currently using green tones.

## Assumptions & Rules
- Both snake head ('@') and body ('*') will be changed to ConsoleColor.Yellow.
- Apple ('●') remains Red; borders ('#') remain default/White.
- Score text ("Apples collected: X/Y") remains Yellow; visual overlap is acceptable since it’s outside the map and not ambiguous.

## Step-by-Step Implementation Plan
1. Open file UI/Renderers/DefaultImplementations/DefaultGameFrameRenderer.cs.
2. Locate method: private static void DrawMap(string[,] map, int levelNumber).
3. Inside the inner loop, find the switch expression that maps the current cell string to Console.ForegroundColor:
   - Cases to modify:
     - "*" => ConsoleColor.DarkGreen
     - "@" => ConsoleColor.Green
4. Change both mappings to ConsoleColor.Yellow so both head and body render in Yellow.
5. Verify other cases remain unchanged:
   - "●" => ConsoleColor.Red
   - Default => ConsoleColor.White
6. Confirm no other render paths override color for the snake:
   - ClearSnakeFromMap(...) only clears symbols; no color changes needed.
   - DrawScore(...) uses ConsoleColor.Yellow for score text; acceptable to keep.
7. Build the solution (SnakeGame.sln) and run Program.cs. Start a game and visually confirm:
   - Snake head and body appear Yellow within the map.
   - Apple remains Red.
   - Borders remain White.
   - Score displays in Yellow below the map.

## Error Handling
- Console color conflicts: If visual ambiguity arises between the score and snake, consider switching score to ConsoleColor.Cyan as a follow-up task (not part of this change).
- Terminal compatibility: If Yellow renders poorly on certain terminals, consider ConsoleColor.DarkYellow as a fallback in a subsequent change.
