### PR TITLE
SCRUM-340 Change Snake Color To Purple

### DIFF
--- a/UI/Renderers/DefaultImplementations/DefaultGameFrameRenderer.cs
+++ b/UI/Renderers/DefaultImplementations/DefaultGameFrameRenderer.cs
@@ -54,8 +54,8 @@ namespace SnakeGame.UI.Renderers.DefaultImplementations
 
                     Console.ForegroundColor = curr switch
                     {
-                        "*" => ConsoleColor.DarkGreen,
-                        "@" => ConsoleColor.Green,
+                        "*" => ConsoleColor.DarkMagenta,
+                        "@" => ConsoleColor.Magenta,
                         "●" => ConsoleColor.Red,
                         _ => ConsoleColor.White
                     };


### PR DESCRIPTION
Implementation of SCRUM-340

Change Snake Color To Purple

# Implementation Plan

## Conceptual Checklist

- Confirm the exact file and lines where snake colors are defined
- Verify which ConsoleColor values best represent 'purple'
- Decide whether head and body should retain a light/dark distinction
- Make the minimal targeted change (2 lines)
- Verify no other files define snake colors

## Overview

Change the snake's rendered color from green to purple in the C# console Snake game. The only required edit is in the color switch expression inside `DefaultGameFrameRenderer.cs`, replacing `ConsoleColor.Green` (head) and `ConsoleColor.DarkGreen` (body) with purple equivalents.

## Assumptions and Rules from CLAUDE.md

- No project CLAUDE.md or global CLAUDE.md with special rules was found.
- Assumption: `ConsoleColor.Magenta` is the closest available value to 'purple' for the snake head, and `ConsoleColor.DarkMagenta` for the body, preserving the existing visual light/dark distinction.
- Assumption: Only the in-game snake rendering should change; menu title color (`DarkGreen`) is intentionally left unchanged.

## Step-by-Step Implementation

1. Open `UI/Renderers/DefaultImplementations/DefaultGameFrameRenderer.cs`
- Dependencies: None
- Tools/Files: Edit tool on `DefaultGameFrameRenderer.cs`

2. In the `DrawMap` method (lines 55–61), change:
- `"@" => ConsoleColor.Green` → `"@" => ConsoleColor.Magenta`
- `"*" => ConsoleColor.DarkGreen` → `"*" => ConsoleColor.DarkMagenta`
- Dependencies: None beyond step 1
- Tools/Files: Edit tool

3. Verify no other files render snake segments with color (confirmed: none exist)
- Dependencies: Step 2
- Tools/Files: Grep search for `Green` in renderer files

## Error Handling and Uncertainties

- **No native 'Purple' in ConsoleColor:** Mitigated by using Magenta/DarkMagenta as the standard purple approximation in .NET console apps.
- **Menu title also uses DarkGreen:** This is intentional branding, not snake color — leave it unchanged.
- **Scope creep risk:** Task says 'snake color'; no reason to change apple, wall, or score colors.