### PR TITLE
SCRUM-341 Сhange Snake Color To Red

### DIFF
--- a/UI/Renderers/DefaultImplementations/DefaultGameFrameRenderer.cs
+++ b/UI/Renderers/DefaultImplementations/DefaultGameFrameRenderer.cs
@@ -54,8 +54,8 @@ namespace SnakeGame.UI.Renderers.DefaultImplementations
 
                     Console.ForegroundColor = curr switch
                     {
-                        "*" => ConsoleColor.DarkGreen,
-                        "@" => ConsoleColor.Green,
+                        "*" => ConsoleColor.DarkRed,
+                        "@" => ConsoleColor.Red,
                         "●" => ConsoleColor.Red,
                         _ => ConsoleColor.White
                     };


### PR DESCRIPTION
Implementation of SCRUM-341

Сhange Snake Color To Red

# Implementation Plan

## Conceptual Checklist

- Confirm which snake parts (head, body, or both) should be red.
- Locate the exact lines in `DefaultGameFrameRenderer.DrawMap` that set `Console.ForegroundColor` for `@` and `*`.
- Choose the appropriate `ConsoleColor` value(s) — `ConsoleColor.Red` or `ConsoleColor.DarkRed`.
- Apply the minimal targeted edit (one switch expression, one file).
- Verify no other renderer or color reference needs updating.

## Overview

Change the snake's rendered color from its current green shades (`ConsoleColor.Green` for the head, `ConsoleColor.DarkGreen` for the body) to red in the console frame renderer. The change is confined to a single `switch` expression in `DefaultGameFrameRenderer.cs`.

## Assumptions and Rules from CLAUDE.md

- **Assumption:** Both head and body should be changed to red (most natural interpretation of "snake color").
- **Assumption:** `ConsoleColor.Red` is used (bright, visible); `ConsoleColor.DarkRed` is an alternative if a subtler distinction between head/body is desired.
- **Project CLAUDE.md:** No test project exists — no test updates needed.
- **Project CLAUDE.md:** `Utilites/` misspelling is intentional — unrelated, but do not "fix" it.
- **Global CLAUDE.md:** Only modify existing files; do not create new files unnecessarily.

## Step-by-Step Implementation

1. Open `UI/Renderers/DefaultImplementations/DefaultGameFrameRenderer.cs`
- Dependencies: None
- Tools/Files: `Edit` tool on `DefaultGameFrameRenderer.cs`

2. In `DrawMap`, locate the `switch` expression that sets `Console.ForegroundColor`:
```csharp
"*" => ConsoleColor.DarkGreen,
"@" => ConsoleColor.Green,
```
Change both to `ConsoleColor.Red`:
```csharp
"*" => ConsoleColor.Red,
"@" => ConsoleColor.Red,
```

3. Build to confirm no compilation errors: `dotnet build`

## Error Handling and Uncertainties

- **Head vs. body distinction:** If the user wants a visual distinction kept (e.g., head = `Red`, body = `DarkRed`), the same edit location accommodates it trivially.
- **Apple color conflict:** The apple (`●`) already uses `ConsoleColor.Red`. If both snake and apple become red, they will be visually indistinguishable. This may be intentional or may require using `ConsoleColor.DarkRed` for the snake. Worth flagging to the requester.
- **Build validation:** `dotnet build` is sufficient to verify the change since there is no test project.